### PR TITLE
Remove aliasing of methods from core

### DIFF
--- a/src/Random/Array.elm
+++ b/src/Random/Array.elm
@@ -10,8 +10,8 @@ module Random.Array where
 -}
 
 import Array        exposing (Array, fromList, empty)
-import Random       exposing (Generator, list, int)
-import Random.Extra exposing (map, flatMap, constant)
+import Random       exposing (Generator, map, list, int)
+import Random.Extra exposing (flatMap, constant)
 
 {-| Generate a random array of given size given a random generator
 

--- a/src/Random/Char.elm
+++ b/src/Random/Char.elm
@@ -10,8 +10,8 @@ module Random.Char where
 -}
 
 import Char         exposing (fromCode)
-import Random       exposing (Generator, int)
-import Random.Extra exposing (map, merge)
+import Random       exposing (Generator, map, int)
+import Random.Extra exposing (merge)
 
 {-| Generate a random character within a certain keyCode range
 

--- a/src/Random/Color.elm
+++ b/src/Random/Color.elm
@@ -7,8 +7,7 @@ module Random.Color where
 -}
 
 import Color        exposing (Color)
-import Random       exposing (Generator, int, float)
-import Random.Extra exposing (map, map3, map4)
+import Random       exposing (Generator, map, map3, map4, int, float)
 
 {-| Generate a random color
 -}

--- a/src/Random/Date.elm
+++ b/src/Random/Date.elm
@@ -8,8 +8,8 @@ module Random.Date where
 
 import Date         exposing (Day(..), Month(..), fromTime, toTime, Date)
 import Time         exposing (Time)
-import Random       exposing (Generator, int, float)
-import Random.Extra exposing (map, selectWithDefault)
+import Random       exposing (Generator, map, int, float)
+import Random.Extra exposing (selectWithDefault)
 
 {-| Generate a random day of the week.
 -}

--- a/src/Random/Dict.elm
+++ b/src/Random/Dict.elm
@@ -7,8 +7,8 @@ module Random.Dict where
 -}
 
 import Dict         exposing (Dict, fromList, empty)
-import Random       exposing (Generator, list, int)
-import Random.Extra exposing (zip, map, flatMap, constant)
+import Random       exposing (Generator, map, list, int)
+import Random.Extra exposing (zip, flatMap, constant)
 
 {-| Generate a random dict with given length, key generator, and value generator
 

--- a/src/Random/Extra.elm
+++ b/src/Random/Extra.elm
@@ -11,10 +11,8 @@ module Random.Extra where
 @docs select, selectWithDefault, frequency, merge
 
 # Maps
-Because `map` and `mapN` up through N=5 were added to the core Random
-library in Elm 0.16, the versions below are aliases and are kept only
-for compatibility with prior versions of this library.
-@docs map, map2, map3, map4, map5, map6, mapConstraint
+For `map` and `mapN` up through N=5, use the core library.
+@docs map6, mapConstraint
 
 # Flat Maps
 @docs flatMap, flatMap2, flatMap3, flatMap4, flatMap5, flatMap6
@@ -26,7 +24,7 @@ for compatibility with prior versions of this library.
 @docs reduce, fold
 
 # Chaining Generators
-@docs andMap, andThen
+@docs andMap
 
 # Filtering Generators
 @docs keepIf, dropIf
@@ -95,7 +93,7 @@ flattenList : List (Generator a) -> Generator (List a)
 flattenList generators =
   case generators of
       [] -> constant []
-      g :: gs -> map2 (::) g (flattenList gs)
+      g :: gs -> Random.map2 (::) g (flattenList gs)
 
 
 {-| Generator that randomly selects an element from a list.
@@ -111,7 +109,7 @@ select list =
 -}
 selectWithDefault : a -> List a -> Generator a
 selectWithDefault defaultValue list =
-  map (Maybe.withDefault defaultValue) (select list)
+  Random.map (Maybe.withDefault defaultValue) (select list)
 
 
 {-| Create a generator that always returns the same value.
@@ -147,34 +145,29 @@ fold = reduce
 
 {-|-}
 zip : Generator a -> Generator b -> Generator (a, b)
-zip = map2 (,)
+zip = Random.map2 (,)
 
 {-|-}
 zip3 : Generator a -> Generator b -> Generator c -> Generator (a, b, c)
-zip3 = map3 (,,)
+zip3 = Random.map3 (,,)
 
 {-|-}
 zip4 : Generator a -> Generator b -> Generator c -> Generator d -> Generator (a, b, c, d)
-zip4 = map4 (,,,)
+zip4 = Random.map4 (,,,)
 
 {-|-}
 zip5 : Generator a -> Generator b -> Generator c -> Generator d -> Generator e -> Generator (a, b, c, d, e)
-zip5 = map5 (,,,,)
+zip5 = Random.map5 (,,,,)
 
 {-|-}
 zip6 : Generator a -> Generator b -> Generator c -> Generator d -> Generator e -> Generator f -> Generator (a, b, c, d, e, f)
 zip6 = map6 (,,,,,)
 
 
-{-| An alias for `Random.andThen` in the standard library. This
-version is kept for compatibility.
--}
-andThen : Generator a -> (a -> Generator b) -> Generator b
-andThen = Random.andThen
-
 {-|-}
 flatMap : (a -> Generator b) -> Generator a -> Generator b
 flatMap = flip Random.andThen
+
 
 {-|-}
 flatMap2 : (a -> b -> Generator c) -> Generator a -> Generator b -> Generator c
@@ -191,6 +184,7 @@ flatMap3 constructor generatorA generatorB generatorC =
     generatorB `Random.andThen` (\b ->
       generatorC `Random.andThen` (\c ->
         constructor a b c)))
+
 
 {-|-}
 flatMap4 : (a -> b -> c -> d -> Generator e) -> Generator a -> Generator b -> Generator c -> Generator d -> Generator e
@@ -212,6 +206,7 @@ flatMap5 constructor generatorA generatorB generatorC generatorD generatorE =
           generatorE `Random.andThen` (\e ->
             constructor a b c d e)))))
 
+
 {-|-}
 flatMap6 : (a -> b -> c -> d -> e -> f -> Generator g) -> Generator a -> Generator b -> Generator c -> Generator d -> Generator e -> Generator f -> Generator g
 flatMap6 constructor generatorA generatorB generatorC generatorD generatorE generatorF =
@@ -225,29 +220,10 @@ flatMap6 constructor generatorA generatorB generatorC generatorD generatorE gene
 
 
 {-|-}
-map : (a -> b) -> Generator a -> Generator b
-map = Random.map
-
-{-|-}
-map2 : (a -> b -> c) -> Generator a -> Generator b -> Generator c
-map2 = Random.map2
-
-{-|-}
-map3 : (a -> b -> c -> d) -> Generator a -> Generator b -> Generator c -> Generator d
-map3 = Random.map3
-
-{-|-}
-map4 : (a -> b -> c -> d -> e) -> Generator a -> Generator b -> Generator c -> Generator d -> Generator e
-map4 = Random.map4
-
-{-|-}
-map5 : (a -> b -> c -> d -> e -> f) -> Generator a -> Generator b -> Generator c -> Generator d -> Generator e -> Generator f
-map5 = Random.map5
-
-{-|-}
 map6 : (a -> b -> c -> d -> e -> f -> g) -> Generator a -> Generator b -> Generator c -> Generator d -> Generator e -> Generator f -> Generator g
 map6 f generatorA generatorB generatorC generatorD generatorE generatorF =
   Random.map5 f generatorA generatorB generatorC generatorD generatorE `andMap` generatorF
+
 
 {-| Choose between two generators with a 50-50 chance.
 Useful for merging two generators that cover different areas of the same type.

--- a/src/Random/Float.elm
+++ b/src/Random/Float.elm
@@ -9,8 +9,7 @@ module Random.Float where
 
 -}
 
-import Random       exposing (Generator, float, maxInt, minInt, generate)
-import Random.Extra exposing (map)
+import Random       exposing (Generator, map, float, maxInt, minInt, generate)
 
 
 {-| Generator that generates any float

--- a/src/Random/Keyboard.elm
+++ b/src/Random/Keyboard.elm
@@ -8,8 +8,8 @@ module Random.Keyboard where
 
 import List
 import Char         exposing (KeyCode)
-import Random       exposing (Generator, int)
-import Random.Extra exposing (map, selectWithDefault)
+import Random       exposing (Generator, map, int)
+import Random.Extra exposing (selectWithDefault)
 
 
 {-| Generate random Keyboard arrows input

--- a/src/Random/Mailbox.elm
+++ b/src/Random/Mailbox.elm
@@ -6,8 +6,7 @@ module Random.Mailbox where
 -}
 
 import Signal       exposing (Mailbox, Address)
-import Random       exposing (Generator)
-import Random.Extra exposing (map)
+import Random       exposing (Generator, map)
 
 
 {-| Generates a random mailbox

--- a/src/Random/Maybe.elm
+++ b/src/Random/Maybe.elm
@@ -6,8 +6,8 @@ module Random.Maybe where
 
 -}
 
-import Random       exposing (Generator)
-import Random.Extra exposing (constant, map, frequency, flatMap)
+import Random       exposing (Generator, map)
+import Random.Extra exposing (constant, frequency, flatMap)
 import Maybe
 
 {-| Generate a Maybe from a generator. Will generate Nothings 50% of the time.

--- a/src/Random/Result.elm
+++ b/src/Random/Result.elm
@@ -6,8 +6,8 @@ module Random.Result where
 
 -}
 
-import Random       exposing (Generator, generate,float)
-import Random.Extra exposing (map, frequency)
+import Random       exposing (Generator, generate, map, float)
+import Random.Extra exposing (frequency)
 
 
 {-| Generate an ok result from a random generator of values

--- a/src/Random/Set.elm
+++ b/src/Random/Set.elm
@@ -10,8 +10,8 @@ module Random.Set where
 -}
 
 import Set          exposing (Set)
-import Random       exposing (Generator, andThen)
-import Random.Extra exposing (constant, map, dropIf, keepIf)
+import Random       exposing (Generator, map, andThen)
+import Random.Extra exposing (constant, dropIf, keepIf)
 
 
 {-| Generator that always returns the empty set

--- a/src/Random/Signal.elm
+++ b/src/Random/Signal.elm
@@ -15,8 +15,8 @@ module Random.Signal where
 -}
 
 import Signal       exposing (Signal)
-import Random       exposing (Generator, Seed)
-import Random.Extra exposing (map, reduce)
+import Random       exposing (Generator, Seed, map)
+import Random.Extra exposing (reduce)
 import Time         exposing (Time)
 
 {-| Generates constant signals.

--- a/src/Random/String.elm
+++ b/src/Random/String.elm
@@ -10,9 +10,9 @@ module Random.String where
 -}
 
 import String exposing (fromList)
-import Random exposing (Generator, list, int)
+import Random exposing (Generator, map, map2, list, int)
 import Random.Char exposing (upperCaseLatin, lowerCaseLatin, unicode)
-import Random.Extra exposing (map, map2, flatMap)
+import Random.Extra exposing (flatMap)
 
 
 

--- a/src/Random/Task.elm
+++ b/src/Random/Task.elm
@@ -17,8 +17,8 @@ module Random.Task where
 
 import Task         exposing (Task, ThreadID, succeed, fail, sleep)
 import Task.Extra   as Task
-import Random       exposing (Generator, float)
-import Random.Extra exposing (map, constant, flatMap)
+import Random       exposing (Generator, map, float)
+import Random.Extra exposing (constant, flatMap)
 import Time         exposing (Time)
 import Signal       exposing (Address)
 

--- a/src/Random/Touch.elm
+++ b/src/Random/Touch.elm
@@ -7,8 +7,8 @@ module Random.Touch where
 -}
 
 import Touch        exposing (Touch)
-import Random       exposing (Generator, int)
-import Random.Extra exposing (map2, map6)
+import Random       exposing (Generator, map2, int)
+import Random.Extra exposing (map6)
 import Random.Int   exposing (anyInt)
 import Random.Float exposing (positiveFloat)
 


### PR DESCRIPTION
Remove `map`, `mapN` for 2 ≤ N ≤ 5, and `andThen`. These methods are exported by core. If you do `import Random.Extra as Random` then these methods become unavailable as they are ambiguous.

Most of the code changes involve importing `map` directly from core in all the child modules.

This removes functions, and would therefore be a major change. Part of me feels that we should use the occasion to, well, clean up a lot and figure out what the heck is going on in this library. But, seeing how it's a *-extra package, I think it's more acceptable to have it be a kitchen sink of functions. 

Well, maybe if it's just paring down `Random.Extra`, it's more feasible. For example, with the new focus on generators rather than seeds, a lot of the interfaces are hard to use.

So yeah, open for comments.
